### PR TITLE
Add `fake.optional`

### DIFF
--- a/src/optional/index.js
+++ b/src/optional/index.js
@@ -1,0 +1,12 @@
+// @flow
+import sample from '../sample';
+
+const returnUndefined = () => undefined;
+
+/**
+ * Returns `undefined` or the result of the supplied `returnValue` function.
+ */
+export default function optional<T>(returnValue: () => T): T | void {
+  const getter = sample([returnUndefined, returnValue]);
+  return getter();
+}


### PR DESCRIPTION
Useful for representing optional properties in Flow, which are of type
`T | void`.

https://flow.org/en/docs/types/objects/#toc-optional-object-type-properties