### PR TITLE
Add support for fake.maybe() with no args to generate nullish values.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,11 +26,11 @@ fake.employee.email(); // => 'rylee.mayert@goodeggs.com
 `<T>(lengthLowerInclusive: number, lengthUpperExclusive: number, generator: () => T) => T[]`
 
 
-Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and `lengthUpperInclusive`.
+Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and
+`lengthUpperExclusive`.
+ 
 
-
-<small>[[view source]](src/array/index.js#L9-L11)</small>
-
+<small>[[view source]](src/array/index.js#L10-L12)</small>
 
 #### `fake.boolean`
 
@@ -345,13 +345,13 @@ Generates a random last name, e.g., `Armstrong`.
 
 <small>[[view source]](src/last_name/index.js#L8-L10)</small>
 
-
+  
 #### `fake.maybe`
 
-`<T>(returnValue: () => T) => ?T`
+`<T>(generator: () => T) => ?T`
 
 
-Potentially returns `null`, `undefined`, or the result of the supplied `returnValue` function.
+Potentially returns `null`, `undefined`, or the result of the supplied `generator` function.
 
 Useful for maybe types in Flow, e.g.:
 
@@ -367,18 +367,8 @@ Useful for maybe types in Flow, e.g.:
 
 #### `fake.nullable`
 
-`<T>(returnValue: () => T) => T | null`
+`<T>(returnValue: () => T) => (T | null)`
 
-
-Potentially returns `null`, or the result of the supplied `returnValue` function.
-
-Useful for nullable types in Flow, e.g.:
-
-```
-{
-  nullableValue: boolean | null,
-}
-```
 
 
 <small>[[view source]](src/nullable/index.js#L17-L21)</small>

--- a/readme.md
+++ b/readme.md
@@ -348,10 +348,11 @@ Generates a random last name, e.g., `Armstrong`.
   
 #### `fake.maybe`
 
-`<T>(generator: () => T) => ?T`
+`<T>(generator?: () => T) => ?T`
 
 
-Potentially returns `null`, `undefined`, or the result of the supplied `generator` function.
+Potentially returns `null`, `undefined`, or the result of the supplied `generator` function, if
+any.
 
 Useful for maybe types in Flow, e.g.:
 
@@ -360,11 +361,11 @@ Useful for maybe types in Flow, e.g.:
   maybeValue: ?boolean,
 }
 ```
+ 
 
+<small>[[view source]](src/maybe/index.js#L19-L27)</small>
 
-<small>[[view source]](src/maybe/index.js#L18-L22)</small>
-
-
+  
 #### `fake.nullable`
 
 `<T>(returnValue: () => T) => (T | null)`

--- a/src/array/index.js
+++ b/src/array/index.js
@@ -4,7 +4,8 @@ import times from 'lodash/times';
 import integer from '../integer';
 
 /**
- * Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and `lengthUpperInclusive`.
+ * Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and
+ * `lengthUpperExclusive`.
  */
 function array <T> (lengthLowerInclusive: number, lengthUpperExclusive: number, generator: () => T): Array<T> {
   return times(integer(lengthLowerInclusive, lengthUpperExclusive), () => generator());

--- a/src/array/test.js
+++ b/src/array/test.js
@@ -1,10 +1,20 @@
 // @flow
 import {describe, it} from 'mocha';
+import {expect} from 'goodeggs-test-helpers';
 
 import array from '.';
+import integer from '../integer';
 
 describe('array', function () {
-  it('works', function () {
-    array(0, 2, () => 'foo');
+ it('returns array of results of calling supplied `generator` function between `lengthLowerInclusive` and `lengthUpperExclusive` times', function () {
+   const lengthLowerInclusive = integer(0);
+   const lengthUpperExclusive = integer(lengthLowerInclusive);
+   const results = array(lengthLowerInclusive, lengthUpperExclusive, () => 'foo');
+   expect(results).to.have.length.of.at.least(lengthLowerInclusive);
+   expect(results).to.have.length.below(lengthUpperExclusive);
+   for (const result of results) {
+     // TODO(serhalp) more sophisticated test involving a stub to verify dynamic return values
+     expect(result).to.equal('foo');
+   }
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -60,3 +60,5 @@ export default {
   uri,
   warehouseLocation
 };
+
+// TODO(serhalp) add eslint/prettier to this repo

--- a/src/maybe/index.js
+++ b/src/maybe/index.js
@@ -5,7 +5,8 @@ const returnUndefined = () => undefined;
 const returnNull = () => null;
 
 /**
- * Potentially returns `null`, `undefined`, or the result of the supplied `generator` function.
+ * Potentially returns `null`, `undefined`, or the result of the supplied `generator` function, if
+ * any.
  *
  * Useful for maybe types in Flow, e.g.:
  *
@@ -15,8 +16,12 @@ const returnNull = () => null;
  * }
  * ```
  */
-function maybe<T>(generator: () => T): ?T {
-  const getter = sample([returnUndefined, returnNull, generator]);
+function maybe<T>(generator?: () => T): ?T {
+  const getter = sample([
+    returnUndefined,
+    returnNull,
+    ...(generator != null ? [generator] : []),
+  ]);
 
   return getter();
 }

--- a/src/maybe/index.js
+++ b/src/maybe/index.js
@@ -5,7 +5,7 @@ const returnUndefined = () => undefined;
 const returnNull = () => null;
 
 /**
- * Potentially returns `null`, `undefined`, or the result of the supplied `returnValue` function.
+ * Potentially returns `null`, `undefined`, or the result of the supplied `generator` function.
  *
  * Useful for maybe types in Flow, e.g.:
  *
@@ -15,8 +15,8 @@ const returnNull = () => null;
  * }
  * ```
  */
-function maybe<T>(returnValue: () => T): ?T {
-  const getter = sample([returnUndefined, returnNull, returnValue]);
+function maybe<T>(generator: () => T): ?T {
+  const getter = sample([returnUndefined, returnNull, generator]);
 
   return getter();
 }

--- a/src/maybe/test.js
+++ b/src/maybe/test.js
@@ -8,4 +8,8 @@ describe('maybe', function () {
  it('returns `null`, `undefined`, or result of calling given `generator` function', function () {
    expect(maybe(() => 'foo')).to.be.oneOf([null, undefined, 'foo']);
  });
+
+ it('returns `null` or `undefined` if no `generator` function given', function () {
+   expect(maybe()).to.be.oneOf([null, undefined]);
+ });
 });

--- a/src/maybe/test.js
+++ b/src/maybe/test.js
@@ -1,0 +1,11 @@
+// @flow
+import {describe, it} from 'mocha';
+import {expect} from 'goodeggs-test-helpers';
+
+import maybe from '.';
+
+describe('maybe', function () {
+ it('returns `null`, `undefined`, or result of calling given `generator` function', function () {
+   expect(maybe(() => 'foo')).to.be.oneOf([null, undefined, 'foo']);
+ });
+});

--- a/src/test.js
+++ b/src/test.js
@@ -28,9 +28,7 @@ describe("the default export", function() {
     expect(fake.warehouseLocation.shelf()).to.be.a("string");
     expect(fake.warehouseLocation.label()).to.be.a("string");
     expect(fake.inventoryLot.label()).to.be.a("string");
-    expect([undefined, null, true, false]).to.include(fake.maybe(fake.boolean));
     expect([null, true, false]).to.include(fake.nullable(fake.boolean));
-    expect(fake.array(0, 2, fake.boolean)).to.be.an.instanceof(Array);
     expect(fake.boolean()).to.be.a("boolean");
     expect(fake.number()).to.be.a("number");
     expect(fake.date()).to.be.an.instanceof(Date);


### PR DESCRIPTION
094574d Support no arguments to `fake.maybe`.

I frequently find myself wanting to generate random nullish values:
```js
fake.sample([null, undefined])
// or
fake.maybe(() => null))
// or
fake.nullable(() => undefined))
```

But IMO this expresses my intent more clearly:
```js
fake.maybe()
```

Also:

b85f864 Improve `fake.array`, `fake.maybe`.
- add tests for `fake.array`
- add tests for `fake.maybe`
- fix typo in doc for `fake.array`
- use consistent variable name for `fake.maybe`