### PR TITLE
string improvement: remove double and on the end spaces

### DIFF
--- a/src/string/index.js
+++ b/src/string/index.js
@@ -1,18 +1,30 @@
 // @flow
 
-import _ from 'lodash';
+import _ from "lodash";
 
-import sample from '../sample';
-import integer from '../integer';
+import sample from "../sample";
+import integer from "../integer";
+
+export const removeDoubleSpace = (str: string): string => str.replace(/\s+/g, " ");
 
 /**
  * Generates a random string, optionally of `length` and using chars from provided `charset`.
  */
-function string (length?: number, charset?: string): string {
+function string(length?: number, charset?: string): string {
   if (length == null) length = integer(1, 40);
-  if (charset == null) charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ ';
-  const chars = charset.split('');
-  return _.times(length, () => sample(chars)).join('');
+  if (charset == null)
+    charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ ";
+  const chars = charset.split("");
+
+  let str = "";
+
+  for (; str.length < length; ) {
+    str += sample(chars);
+
+    if (str.length === length) str = removeDoubleSpace(str).trim();
+  }
+
+  return str;
 }
 
 export default string;

--- a/src/string/test.js
+++ b/src/string/test.js
@@ -6,7 +6,7 @@ import { expect } from "goodeggs-test-helpers";
 import integer from "../integer";
 import string, { removeDoubleSpace } from ".";
 
-const removeDuplicates = (str: string): string[] => _.uniq(str.split(""));
+const removeDuplicates = (str: string): Array<string> => _.uniq(str.split(""));
 
 describe("string", function() {
   it("generates a random string", function() {
@@ -26,9 +26,9 @@ describe("string", function() {
     const charsetChars = removeDuplicates(charset);
 
     expect(chars)
-      .to.be.an("array")
-      .that.has.length(charsetChars.length)
-      .that.have.members(charsetChars);
+      .to.be.an.instanceOf(Array)
+      .that.has.an.lengthOf(charsetChars.length)
+      .that.has.members(charsetChars);
   });
 
   it("generates a random without double space and right side space", function() {

--- a/src/string/test.js
+++ b/src/string/test.js
@@ -1,0 +1,42 @@
+// @flow
+import _ from "lodash";
+import { describe, it } from "mocha";
+import { expect } from "goodeggs-test-helpers";
+
+import integer from "../integer";
+import string, { removeDoubleSpace } from ".";
+
+const removeDuplicates = (str: string): string[] => _.uniq(str.split(""));
+
+describe("string", function() {
+  it("generates a random string", function() {
+    expect(string()).to.be.an("string");
+  });
+
+  it("generates a random string with legth passed-in", function() {
+    const length = integer(1);
+
+    expect(string(length).length).to.be.equal(length);
+  });
+
+  it("generates a random string with charset passed-in", function() {
+    const charset = Math.random().toString(36); // generate a random charset
+    const length = integer(100);
+    const chars = removeDuplicates(string(length, charset));
+    const charsetChars = removeDuplicates(charset);
+
+    expect(chars)
+      .to.be.an("array")
+      .that.has.length(charsetChars.length)
+      .that.have.members(charsetChars);
+  });
+
+  it("generates a random without double space and right side space", function() {
+    const charset = "a      bc ";
+    const generatedString = string(integer(100), charset);
+
+    expect(generatedString.length).to.be.equal(
+      removeDoubleSpace(generatedString).length
+    );
+  });
+});


### PR DESCRIPTION
### Background
Sometimes the `fake.string` was generating random strings with double spaces or spaces at the end of the content.

It was generating many React Native errors when it was happening because of the `react-testing-library`(https://www.native-testing-library.com/), library that we're using to make our tests, don't make this validation without send normalization text options(https://www.native-testing-library.com/docs/api-queries#normalization).

Talking with @ndhoule about it, he told that it could be a not intentional behavior by this function.

The proposed here is to avoid strings with double spaces or spaces at the end.