### PR TITLE
add: fake word and fake sentence

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,14 @@ interface FakeEggs {
   email: Email;
 
   /**
+   * Generates a random sentence (a string with multiple words), optionally of `length` and using chars from provided `charset`.
+   */
+  sentence: () => string;
+  /**
+   * Generates a random word (a string without any white space), optionally of `length` and using chars from provided `charset`.
+   */
+  word: (length?: number, charset?: string) => string;
+  /**
    * Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and
    * `lengthUpperInclusive`.
    */

--- a/src/sentence/index.js
+++ b/src/sentence/index.js
@@ -1,0 +1,14 @@
+// @flow
+import _ from 'lodash';
+
+import word from '../word';
+import integer from '../integer';
+
+/**
+ * Generates a random sentence (a string with multiple words).
+ */
+const sentence = (): string => {
+  return _.times(integer(5, 10), () => word()).join(' ');
+};
+
+export default sentence;

--- a/src/word/index.js
+++ b/src/word/index.js
@@ -1,0 +1,15 @@
+// @flow
+import string from '../string';
+
+/**
+ * Generates a random word (a string without any whitespace), optionally of `length` and using chars
+ * from provided `charset`.
+ */
+const word = (length?: number, charset?: string): string => {
+  if (charset == null) {
+    charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  }
+  return string(length, charset);
+};
+
+export default word;


### PR DESCRIPTION
### Background
`fake.word`: useful to generate strings without white spaces
`fake.sentence`: useful to generate strings with multiple words

Why?
`fake.string` generate strings with double spaces within the content and end spaces.

Reference: https://github.com/goodeggs/fake-eggs/pull/35#issuecomment-572263004