### PR TITLE
fix: add the word and sentence exports on the index

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,11 @@ fake.employee.email(); // => 'rylee.mayert@goodeggs.com
 
 
 Calls supplied `generator` function to return an array of length `lengthLowerInclusive` and `lengthUpperInclusive`.
-
+ 
 
 <small>[[view source]](src/array/index.js#L9-L11)</small>
 
-
+  
 #### `fake.boolean`
 
 `() => boolean`
@@ -42,7 +42,7 @@ Returns `true` or `false`, chosen at random.
 
 <small>[[view source]](src/boolean/index.js#L7-L9)</small>
 
-
+  
 #### `fake.customer.firstName`
 
 `() => string`
@@ -53,7 +53,7 @@ Returns a randomly-selected first name, e.g. `Carter`.
 
 <small>[[view source]](src/first_name/index.js#L7-L9)</small>
 
-
+  
 #### `fake.customer.lastName`
 
 `() => string`
@@ -64,7 +64,7 @@ Generates a random last name, e.g., `Armstrong`.
 
 <small>[[view source]](src/last_name/index.js#L8-L10)</small>
 
-
+  
 #### `fake.customer.phoneNumber`
 
 `() => string`
@@ -75,18 +75,18 @@ Generates a random phone number, e.g. `+15556797779`.
 
 <small>[[view source]](src/phone_number/index.js#L9-L11)</small>
 
-
+  
 #### `fake.customer.fullName`
 
 `(firstName?: string, lastName?: string) => string`
 
 
 Randomly generates a full name, e.g., `Randall Munroe`. `firstName` and `lastName` can optionally be overridden.
-
+ 
 
 <small>[[view source]](src/full_name/index.js#L8-L12)</small>
 
-
+  
 #### `fake.customer.email`
 
 `(options?: {domain?: string, username?: string}) => string`
@@ -94,33 +94,33 @@ Randomly generates a full name, e.g., `Randall Munroe`. `firstName` and `lastNam
 
 Returns a randomly-selected email address string (e.g., `dualityhiss@icicle.net`).
 You can override either portion of the email with `username` and `domain` options.
-
+ 
 
 <small>[[view source]](src/email/index.js#L9-L16)</small>
 
-
+  
 #### `fake.date`
 
 `(from?: (Date | string), to?: (Date | string)) => Date`
 
 
 Returns a randomly-selected `Date`, optionally between `from` and `to`.
-
+ 
 
 <small>[[view source]](src/date/index.js#L12-L23)</small>
 
-
+  
 #### `fake.day`
 
 `(from?: (Date | string), to?: (Date | string)) => string`
 
 
 Returns a randomly-selected day string (`YYYY-MM-DD`), optionally between `from` and `to`.
-
+ 
 
 <small>[[view source]](src/day/index.js#L10-L16)</small>
 
-
+  
 #### `fake.digit`
 
 `() => number`
@@ -131,7 +131,7 @@ Returns a randomly-selected digit (integer between 0 and 9).
 
 <small>[[view source]](src/digit/index.js#L7-L7)</small>
 
-
+  
 #### `fake.email`
 
 `(options?: {domain?: string, username?: string}) => string`
@@ -139,11 +139,11 @@ Returns a randomly-selected digit (integer between 0 and 9).
 
 Returns a randomly-selected email address string (e.g., `dualityhiss@icicle.net`).
 You can override either portion of the email with `username` and `domain` options.
-
+ 
 
 <small>[[view source]](src/email/index.js#L9-L16)</small>
 
-
+  
 #### `fake.employee.firstName`
 
 `() => string`
@@ -154,7 +154,7 @@ Returns a randomly-selected first name, e.g. `Carter`.
 
 <small>[[view source]](src/first_name/index.js#L7-L9)</small>
 
-
+  
 #### `fake.employee.lastName`
 
 `() => string`
@@ -165,7 +165,7 @@ Generates a random last name, e.g., `Armstrong`.
 
 <small>[[view source]](src/last_name/index.js#L8-L10)</small>
 
-
+  
 #### `fake.employee.phoneNumber`
 
 `() => string`
@@ -176,18 +176,18 @@ Generates a random phone number, e.g. `+15556797779`.
 
 <small>[[view source]](src/phone_number/index.js#L9-L11)</small>
 
-
+  
 #### `fake.employee.fullName`
 
 `(firstName?: string, lastName?: string) => string`
 
 
 Randomly generates a full name, e.g., `Randall Munroe`. `firstName` and `lastName` can optionally be overridden.
-
+ 
 
 <small>[[view source]](src/full_name/index.js#L8-L12)</small>
 
-
+  
 #### `fake.employee.email`
 
 `(options?: {firstName?: string, lastName?: string}) => string`
@@ -195,11 +195,11 @@ Randomly generates a full name, e.g., `Randall Munroe`. `firstName` and `lastNam
 
 Returns a randomly-selected email address at goodeggs.com of the form `randall.munroe@goodeggs.com`.
 You can override `firstName` and `lastName` by providing appropriate options.
-
+ 
 
 <small>[[view source]](src/employee/index.js#L22-L32)</small>
 
-
+  
 #### `fake.factory`
 
 `<T: Object>(defaults: DefaultCreatorsFor<T>) => Factory<T>`
@@ -252,11 +252,11 @@ In this case, flow will complain if:
 
 Additionally, flow will understand that the resulting object created by the factory
 is of the provided type.
-
+ 
 
 <small>[[view source]](src/factory/index.js#L55-L66)</small>
 
-
+  
 #### `fake.firstName`
 
 `() => string`
@@ -267,7 +267,7 @@ Returns a randomly-selected first name, e.g. `Carter`.
 
 <small>[[view source]](src/first_name/index.js#L7-L9)</small>
 
-
+  
 #### `fake.foodhub.slug`
 
 `() => string`
@@ -278,18 +278,18 @@ Returns a randomly-selected foodhub slug, e.g. `sfbay`.
 
 <small>[[view source]](src/foodhub/index.js#L8-L10)</small>
 
-
+  
 #### `fake.fullName`
 
 `(firstName?: string, lastName?: string) => string`
 
 
 Randomly generates a full name, e.g., `Randall Munroe`. `firstName` and `lastName` can optionally be overridden.
-
+ 
 
 <small>[[view source]](src/full_name/index.js#L8-L12)</small>
 
-
+  
 #### `fake.globallyUniqueString`
 
 `(unknown)`
@@ -308,22 +308,22 @@ uniqueFoo() // => "foo_0"
 uniqueFoo() // => "foo_1"
 uniqueFoo() // => "foo_2"
 ```
-
+ 
 
 <small>[[view source]](src/globally_unique_string/index.js#L20-L29)</small>
 
-
+  
 #### `fake.integer`
 
 `(lowerInclusive?: number, upperExclusive?: number) => number`
 
 
 Generates a random integer (could be negative!). Optionally between `lowerExclusive` and `upperExclusive`.
-
+ 
 
 <small>[[view source]](src/integer/index.js#L6-L10)</small>
 
-
+  
 #### `fake.inventoryLot.label`
 
 `() => string`
@@ -334,7 +334,7 @@ Generates an inventory lot label, e.g., "F1A4"
 
 <small>[[view source]](src/inventory_lot/index.js#L8-L10)</small>
 
-
+  
 #### `fake.lastName`
 
 `() => string`
@@ -345,7 +345,7 @@ Generates a random last name, e.g., `Armstrong`.
 
 <small>[[view source]](src/last_name/index.js#L8-L10)</small>
 
-
+  
 #### `fake.maybe`
 
 `<T>(returnValue: () => T) => ?T`
@@ -360,52 +360,42 @@ Useful for maybe types in Flow, e.g.:
   maybeValue: ?boolean,
 }
 ```
-
+ 
 
 <small>[[view source]](src/maybe/index.js#L18-L22)</small>
 
-
+  
 #### `fake.nullable`
 
-`<T>(returnValue: () => T) => T | null`
+`<T>(returnValue: () => T) => (T | null)`
 
-
-Potentially returns `null`, or the result of the supplied `returnValue` function.
-
-Useful for nullable types in Flow, e.g.:
-
-```
-{
-  nullableValue: boolean | null,
-}
-```
 
 
 <small>[[view source]](src/nullable/index.js#L17-L21)</small>
 
-
+  
 #### `fake.number`
 
 `(lowerInclusive?: number, upperExclusive?: number) => number`
 
 
 Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive`.
-
+ 
 
 <small>[[view source]](src/number/index.js#L7-L12)</small>
 
-
+  
 #### `fake.objectId`
 
 `({+counter?: number, +from?: (string | Date), +machineId?: number, +processId?: number, +timestamp?: (string | Date | number), +to?: (string | Date)}) => string`
 
 
 Generates a random mongodb-friendly objectId string.
-
+ 
 
 <small>[[view source]](src/object_id/index.js#L11-L42)</small>
 
-
+  
 #### `fake.optional`
 
 `<T>(returnValue: () => T) => (T | void)`
@@ -414,7 +404,7 @@ Generates a random mongodb-friendly objectId string.
 
 <small>[[view source]](src/optional/index.js#L17-L20)</small>
 
-
+  
 #### `fake.phoneNumber`
 
 `() => string`
@@ -425,7 +415,7 @@ Generates a random phone number, e.g. `+15556797779`.
 
 <small>[[view source]](src/phone_number/index.js#L9-L11)</small>
 
-
+  
 #### `fake.producer.name`
 
 `() => string`
@@ -436,7 +426,7 @@ Generates a random producer name, e.g., `Bahringer`.
 
 <small>[[view source]](src/producer/index.js#L10-L12)</small>
 
-
+  
 #### `fake.producer.slug`
 
 `(nameArg?: string) => string`
@@ -444,11 +434,11 @@ Generates a random producer name, e.g., `Bahringer`.
 
 Generates a random producer slug, e.g., `anderson`.
 Optionally can override with an explicit name to generate from.
-
+ 
 
 <small>[[view source]](src/producer/index.js#L18-L20)</small>
 
-
+  
 #### `fake.product.name`
 
 `() => string`
@@ -459,7 +449,7 @@ Generates a random product name, e.g. `Hargrand Apricots`.
 
 <small>[[view source]](src/product/index.js#L10-L12)</small>
 
-
+  
 #### `fake.product.unit`
 
 `() => string`
@@ -470,7 +460,7 @@ Generates a random product unit, e.g. `count`.
 
 <small>[[view source]](src/product/index.js#L17-L19)</small>
 
-
+  
 #### `fake.product.count`
 
 `() => number`
@@ -481,7 +471,7 @@ Generates a random product count, e.g., `31`.
 
 <small>[[view source]](src/product/index.js#L31-L33)</small>
 
-
+  
 #### `fake.product.storageType`
 
 `() => string`
@@ -492,52 +482,61 @@ Generates a random storage type, e.g., `chill`.
 
 <small>[[view source]](src/product/index.js#L24-L26)</small>
 
-
+  
 #### `fake.sample`
 
 `<T>(array: T[]) => T`
 
 
 Chooses one of the elements of the provided `array`.
-
+ 
 
 <small>[[view source]](src/sample/index.js#L8-L10)</small>
 
+  
+#### `fake.sentence`
 
+`() => string`
+
+
+
+<small>[[view source]](src/sentence/index.js#L10-L12)</small>
+
+  
 #### `fake.string`
 
 `(length?: number, charset?: string) => string`
 
 
 Generates a random string, optionally of `length` and using chars from provided `charset`.
-
+ 
 
 <small>[[view source]](src/string/index.js#L11-L16)</small>
 
-
+  
 #### `fake.tzid`
 
 `() => string`
 
 
 Generate a random tzid, e.g., `America/Denver`.
-
+ 
 
 <small>[[view source]](src/tzid/index.js#L8-L10)</small>
 
-
+  
 #### `fake.uri`
 
 `(domain?: string) => string`
 
 
 Generate a random URI, e.g., `https://adl2j.goodeggs.com/ax/faj23`
-@param {*} domain
-
+@param {*} domain 
+ 
 
 <small>[[view source]](src/uri/index.js#L13-L27)</small>
 
-
+  
 #### `fake.warehouseLocation.zone`
 
 `() => string`
@@ -548,7 +547,7 @@ Returns a random zone, e.g. `chill`.
 
 <small>[[view source]](src/warehouse_location/index.js#L9-L11)</small>
 
-
+  
 #### `fake.warehouseLocation.aisle`
 
 `() => string`
@@ -559,7 +558,7 @@ Returns a random aisle, e.g., `F`.
 
 <small>[[view source]](src/warehouse_location/index.js#L16-L18)</small>
 
-
+  
 #### `fake.warehouseLocation.rack`
 
 `() => string`
@@ -570,7 +569,7 @@ Returns a random rack, e.g., `12`;
 
 <small>[[view source]](src/warehouse_location/index.js#L23-L25)</small>
 
-
+  
 #### `fake.warehouseLocation.shelf`
 
 `() => string`
@@ -581,18 +580,27 @@ Returns a random shelf, e.g., `3`
 
 <small>[[view source]](src/warehouse_location/index.js#L30-L32)</small>
 
-
+  
 #### `fake.warehouseLocation.label`
 
 `() => string`
 
 
 Returns a location label for a warehouse location, e.g., `cF12-3`
-
+ 
 
 <small>[[view source]](src/warehouse_location/index.js#L37-L39)</small>
 
+  
+#### `fake.word`
 
+`(length?: number, charset?: string) => string`
+
+
+
+<small>[[view source]](src/word/index.js#L8-L13)</small>
+
+  
 <!-- automatically generated documentation ends here. -->
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,12 @@ import phoneNumber from "./phone_number";
 import producer from "./producer";
 import product from "./product";
 import sample from "./sample";
+import sentence from './sentence'
 import string from "./string";
 import tzid from "./tzid";
 import uri from "./uri";
 import warehouseLocation from "./warehouse_location";
+import word from './word'
 
 export default {
   array,
@@ -55,8 +57,10 @@ export default {
   producer,
   product,
   sample,
+  sentence,
   string,
   tzid,
   uri,
-  warehouseLocation
+  warehouseLocation,
+  word,
 };


### PR DESCRIPTION
### Background
The new functions weren't exported by the index. To use it we currently need to set the complete folder path(e.g. `fake-eggs/word`).

### Changes
- Added `word` and `sentence` export in the file `index`;
- `yarn build` to regenerate the readme;