### PR TITLE
Add missing type definition for globallyUniqueString

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,11 @@ interface FakeEggs {
   /**
    * Generates a random string, optionally of `length` and using chars from provided `charset`.
    */
-  string: (length?: number, charset?: string) => string;
+  string: (length?: number, charset?: string) => string;  
+  /**
+   * Makes a function that will return an internally globally unique string by appending a monotonically-increasing integer.
+   */
+  globallyUniqueString:  <T>(generator?: (arg: T) => string) => (arg: T) => string;
   /**
    * Generate a random tzid, e.g., `America/Denver`.
    */


### PR DESCRIPTION
## Background
While migrating catalog-api to Typescript we found that `globallyUniqueString` is missing in the lib`s types definition, causing a bunch of errors.

## Changes

 - Add `globallyUniqueString` definition to `index.d.ts`;