### PR TITLE
docs: add fake.array notice to v5 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - fix: `fake.sample` throws when passed array of length `0` to fix possible type mismatch
 - fix: `fake.date` validates arguments (`from`/`to`)
+- fix: `fake.array` validates arguments (throws if upper exclusive bound is less than or equal to inclusive lower bound)
 
 ## Features
 


### PR DESCRIPTION
This just confused me for several minutes. It looks like some tests were incorrectly interpreting the second argument as an inclusive bound and doing impossible things like:
```js
fake.array(3, 3, () => foo)
```