### PR TITLE
fix: make Typescript declaration file actually valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/chance": "^1.1.0",
     "chance": "^1.1.6",
     "debug": "^4.1.1"
   },
@@ -47,7 +48,6 @@
     "@babel/preset-typescript": "^7.10.1",
     "@goodeggs/toolkit": "^2.0.0",
     "@goodeggs/tsconfig": "^1.0.0",
-    "@types/chance": "^1.1.0",
     "@types/debug": "^4.1.5",
     "@types/jest": "^25.1.3",
     "babel-jest": "^25.1.0",


### PR DESCRIPTION
Apparently any external types you reference in your published declaration file have to be included as dependencies of your module (by being regulart dependencies).

(This took me way too long to figure out. It seems somewhat obvious in hindsight, but this doesn't appear to be documented anywhere... Though now that I know what to look for, I found it documented here: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html. Oh well.)

The funny thing is the only actual reference to Chance types in the declaration file [is incorrect](https://github.com/goodeggs/fake-eggs/pull/45#discussion_r454397535) and shouldn't be there in the first place.