### PR TITLE
Change slugify to remove dashes and hyphens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@
  * Lowercases and removes spaces from a string, so that it can be used as a slug.
  */
 export const slugify = (text: string): string => {
-  return text.toLowerCase().replace(/[^\w\-_]+/g, ''); // remove all non-word characters
+  return text.toLowerCase().replace(/[\W_]/g, ''); // remove all non-word characters
 };
 
 declare const nes: unique symbol;


### PR DESCRIPTION
When we need to create a slug, we need to use only alphanumeric characters, so we need to ignore dashes and hyphens