### PR TITLE
feat: update list of possible foodhub slugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "6.0.0",
+  "version": "6.0.3",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/src/generators/foodhub/index.ts
+++ b/src/generators/foodhub/index.ts
@@ -3,7 +3,7 @@ import {Chance} from 'chance';
 import createSampleGenerator from '../sample';
 
 // TODO(ndhoule): Use goodeggs-foodhubs
-const foodhubSlugs = ['sfbay', 'la', 'nola', 'nyc', 'tomorrowland'];
+const foodhubSlugs = ['sfbay', 'la', 'nola', 'nyc', 'MAR1', 'OKN2'];
 
 /**
  * Returns a randomly-selected foodhub slug, e.g. `sfbay`.


### PR DESCRIPTION
## Background
In [goodegg-foodhubs v5](https://github.com/goodeggs/goodeggs-foodhubs/releases/tag/v5.0.0), we've removed `tomorrowland` as a `foodhub`. This is causing tests to flake when `tomorrowland` is returned by `fake.foodhub.slug()`, in order to fix this PR attempts to bring the list of possible `foodhubSlugs` to reflect to most up to date [foodhubs](https://github.com/goodeggs/goodeggs-foodhubs/blob/master/src/index.ts).

## Changes
- feat: updated possible `foodhubSlugs`

## To Do
- [ ] publish a `patch` release  

cc: @hsingh6764 