### PR TITLE
feat(integer): generate valid GraphQL integers by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "6.0.6",
+  "version": "6.1.0",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/src/generators/integer/index.test.ts
+++ b/src/generators/integer/index.test.ts
@@ -3,14 +3,14 @@ import {Chance} from 'chance';
 import createIntegerGenerator from '.';
 
 describe('integer', () => {
-  it('generates a value in the range -9007199254740991 to 9007199254740991', (): void => {
+  it('generates a value in the range -2147483648 to 2147483647', (): void => {
     const chance = new Chance();
     const integer = createIntegerGenerator(chance);
 
     const value = integer();
 
-    expect(value).toBeGreaterThanOrEqual(-9007199254740991);
-    expect(value).toBeLessThanOrEqual(9007199254740991);
+    expect(value).toBeGreaterThanOrEqual(-2147483648);
+    expect(value).toBeLessThan(2147483647);
   });
 
   it('generates a value greater than or equal to `lowerInclusive`', (): void => {

--- a/src/generators/integer/index.ts
+++ b/src/generators/integer/index.ts
@@ -5,7 +5,7 @@ import {Chance} from 'chance';
  * See https://chancejs.com/basics/integer.html.
  *
  * However, per the GraphQL spec, Integers are only treated as valid when they are representable as
- * a 32-bit signed integer, providing the broadest support across platforms.
+ * a 32-bit signed integer: https://spec.graphql.org/June2018/#sec-Int.
  *
  * It doesn't seem worthwhile to provide two separate integer functions in fake-eggs, nor to require
  * thousands of calls to `fake.integer()` across apps that use GraphQL to pass in ranges to deal

--- a/src/generators/integer/index.ts
+++ b/src/generators/integer/index.ts
@@ -1,18 +1,32 @@
 import {Chance} from 'chance';
 
 /**
+ * By default, Chance.js would use range -9007199254740991 (-2^53 - 1) to 9007199254740991 (2^53 - 1).
+ * See https://chancejs.com/basics/integer.html.
+ *
+ * However, per the GraphQL spec, Integers are only treated as valid when they are representable as
+ * a 32-bit signed integer, providing the broadest support across platforms.
+ *
+ * It doesn't seem worthwhile to provide two separate integer functions in fake-eggs, nor to require
+ * thousands of calls to `fake.integer()` across apps that use GraphQL to pass in ranges to deal
+ * with this inconsistency, so just default to a valid 32-bit signed integer range here.
+ *
+ */
+const DEFAULT_LOWER_INCLUSIVE = -2147483648;
+const DEFAULT_UPPER_EXCLUSIVE = 2147483647;
+
+/**
  * Generates a random integer (could be negative!). Optionally between `lowerExclusive` and `upperExclusive`.
- * If `lowerInclusive` or `upperExclusive` are not supplied Chance.js will use the range: -9007199254740991 to 9007199254740991
- * https://chancejs.com/basics/integer.html
+ * If `lowerInclusive` or `upperExclusive` are not supplied, will be between -2147483648 and 2147483647.
  */
 const createIntegerGenerator = (chance: Chance.Chance) => (
-  lowerInclusive?: number,
-  upperExclusive?: number,
+  lowerInclusive: number = DEFAULT_LOWER_INCLUSIVE,
+  upperExclusive: number = DEFAULT_UPPER_EXCLUSIVE,
 ): number =>
   chance.integer({
     min: lowerInclusive,
     // chance.integer's max param is inclusive
-    max: upperExclusive != null ? upperExclusive - 1 : upperExclusive,
+    max: upperExclusive - 1,
   });
 
 export default createIntegerGenerator;


### PR DESCRIPTION
By default, Chance.js would use range -9007199254740991 (-2^53 - 1) to 9007199254740991 (2^53 - 1).  See https://chancejs.com/basics/integer.html.

However, per the GraphQL spec, Integers are only treated as valid when they are representable as a 32-bit signed integer, providing the broadest support across platforms.

It doesn't seem worthwhile to provide two separate integer functions in fake-eggs, nor to require thousands of calls to `fake.integer()` across apps that use GraphQL (Garbanzo and Catalog API, today) to pass in ranges to deal with this inconsistency, so just default to a valid 32-bit signed integer range here.

🍐 with @marco-maturana 