### PR TITLE
feat(day): narrow default range of fake.day() and validate its args

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   clearMocks: true,
+  setupFilesAfterEnv: ['./jest.setup.ts'],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,3 @@
+// The indirection created by this file is necessary for TypeScript to know we're importing
+// jest-extended and thus know about the extended type declaration.
+import 'jest-extended';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/jest": "^26.0.15",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
+    "jest-extended": "^0.11.5",
     "typescript": "^4.1.2"
   }
 }

--- a/src/generators/date/index.test.ts
+++ b/src/generators/date/index.test.ts
@@ -3,16 +3,14 @@ import {Chance} from 'chance';
 import createDateGenerator from '.';
 
 describe('date', () => {
-  it('generates a date in the range `-271821-04-20T00:00:00.000Z` to `+275760-09-13T00:00:00.000Z`', (): void => {
+  it('generates a date in the range `1001-01-01T00:00:00.000Z` to `9999-01-01T00:00:00.000Z`', (): void => {
     const chance = new Chance();
     const date = createDateGenerator(chance);
 
     const value = date();
 
-    expect(value.valueOf()).toBeGreaterThanOrEqual(
-      new Date('-271821-04-20T00:00:00.000Z').valueOf(),
-    );
-    expect(value.valueOf()).toBeLessThanOrEqual(new Date('+275760-09-13T00:00:00.000Z').valueOf());
+    expect(value.valueOf()).toBeGreaterThanOrEqual(new Date('1001-01-01T00:00:00.000Z').valueOf());
+    expect(value.valueOf()).toBeLessThanOrEqual(new Date('9999-01-01T00:00:00.000Z').valueOf());
   });
 
   it('generates a value greater than or equal to `from`', (): void => {

--- a/src/generators/date/index.ts
+++ b/src/generators/date/index.ts
@@ -7,21 +7,22 @@ const dateInSeconds = (_date: Date | string): number => {
 };
 
 /**
+ * For convenience of compatibility with `fake.day()` defaults, use 1001-01-01 00:00:00 and
+ * 9999-01-01 00:00:00 as the default `from` and `to`, respectively. See comment in `fake.day()` for
+ * context on why we use these defaults.
+ */
+const DEFAULT_FROM = new Date(-30578688000000);
+const DEFAULT_TO = new Date(253370764800000);
+
+/**
  * Returns a randomly-selected `Date`, optionally between `from` and `to`.
  */
 const createDateGenerator = (chance: Chance.Chance) => (
-  from?: Date | string,
-  to?: Date | string,
+  from: Date | string = DEFAULT_FROM,
+  to: Date | string = DEFAULT_TO,
 ): Date => {
-  // https://tc39.es/ecma262/#sec-time-values-and-time-range
-  // https://tc39.es/ecma262/#_ref_6257:~:text=A%20Number%20can%20exactly%20represent%20all,beginning%20of%2001%20January%2C%201970%20UTC.
-  const minTimeMilliseconds = -8640000000000000;
-  const maxTimeMilliseconds = 8640000000000000;
   const integer = createIntegerGenerator(chance);
 
-  if (from == null) {
-    from = new Date(minTimeMilliseconds);
-  }
   if (typeof from === 'string') {
     from = new Date(from);
   }
@@ -29,9 +30,6 @@ const createDateGenerator = (chance: Chance.Chance) => (
     throw new RangeError('`from` is not a valid date');
   }
 
-  if (to == null) {
-    to = new Date(maxTimeMilliseconds);
-  }
   if (typeof to === 'string') {
     to = new Date(to);
   }

--- a/src/generators/day/index.test.ts
+++ b/src/generators/day/index.test.ts
@@ -1,0 +1,82 @@
+import {Chance} from 'chance';
+
+import createDayGenerator, {DEFAULT_FROM, DEFAULT_TO} from '.';
+
+// Neither jest nor jest-extended has any expressive assertions for comparing *strings*. 🤷
+const greaterThanOrEqualTo = (max: string) => (value: string): boolean => value >= max;
+const lessThan = (min: string) => (value: string): boolean => value < min;
+const lessThanOrEqualTo = (min: string) => (value: string): boolean => value <= min;
+
+describe('day', () => {
+  it('throws an error given a `from` string with format other than YYYY-MM-DD', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const from = '202020-10-13';
+
+    expect(() => date(from)).toThrow('`from` must be a Date or a YYYY-MM-DD string');
+  });
+
+  it('throws an error given a `to` string with format other than YYYY-MM-DD', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const to = '202020-10-13';
+
+    expect(() => date(undefined, to)).toThrow('`to` must be a Date or a YYYY-MM-DD string');
+  });
+
+  it(`generates a day in the range "${DEFAULT_FROM}" to "${DEFAULT_TO}" given no arguments`, (): void => {
+    const chance = new Chance();
+    const day = createDayGenerator(chance);
+    const value = day();
+
+    expect(value).toSatisfy(greaterThanOrEqualTo(DEFAULT_FROM));
+    expect(value).toSatisfy(lessThan(DEFAULT_TO));
+  });
+
+  it('generates a day greater than or equal the given `from` date string', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const from = '2020-10-13';
+    const value = date(from);
+
+    expect(value).toSatisfy(greaterThanOrEqualTo(from));
+  });
+
+  it('generates a day greater than or equal to the day in the given `from` Date', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const from = new Date('2020-10-13T12:00:00.000Z');
+    const value = date(from);
+
+    expect(value).toSatisfy(greaterThanOrEqualTo('2020-10-13'));
+  });
+
+  it('generates a day less than given `to` date string', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const to = '2020-10-13';
+    const value = date(undefined, to);
+
+    expect(value).toSatisfy(lessThan(to));
+  });
+
+  it('generates a day less than or equal to the day in the given `to` Date', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const to = new Date('2020-10-13T12:00:00.000Z');
+    const value = date(undefined, to);
+
+    expect(value).toSatisfy(lessThanOrEqualTo('2020-10-13'));
+  });
+
+  it('generates a value that is greater than or equal to given `from` and less than given `to`', (): void => {
+    const chance = new Chance();
+    const date = createDayGenerator(chance);
+    const from = '2020-10-13';
+    const to = '2020-10-18';
+    const value = date(from, to);
+
+    expect(value).toSatisfy(greaterThanOrEqualTo(from));
+    expect(value).toSatisfy(lessThan(to));
+  });
+});

--- a/src/generators/day/index.ts
+++ b/src/generators/day/index.ts
@@ -2,15 +2,59 @@ import {Chance} from 'chance';
 
 import createDateGenerator from '../date';
 
+// Avoids pulling in something like moment.js just for this.
+const DAY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
- * Returns a randomly-selected day string (`YYYY-MM-DD`), optionally between `from` and `to`.
+ * Strictly speaking, the ISO 8601 date format, though often abbreviated as "YYYY-MM-DD", allows for
+ * an "extended" format containing a year with 5 to 6 digits preceded by a +/- sign:
+ * https://tc39.es/ecma262/#sec-expanded-years.
+ *
+ * For convenience, this can be further narrowed to the range that would be expressible as
+ * JavaScript `Dates`: approximately -271821-04-20 to +275760-09-13.
+ *
+ * However, supporting these formats breaks a number of assumptions in Good Eggs code and perhaps in
+ * third-party libraries:
+ * - sorting "date" strings alphanumerically results in a chronological sort
+ * - extracting the "date" part of a `Date` as "YYYY-MM-DD" will always work
+ * - etc.
+ *
+ * It doesn't seem worthwhile to require thousands of calls to `fake.day()` across repos that use
+ * fake-eggs to pass in custom ranges to deal with this, nor to require thousands of calls to
+ * moment.js's `.format('YYYY-MM-DD')` to be updated, since realistically we will never need to
+ * manipulate dates over a thousand years ago nor dates eight thousand years from now, and
+ * realistically our code will not run for eight thousand years. Therefore, we choose to support a
+ * further narrowed range called "Complete date" by the W3C: https://www.w3.org/TR/NOTE-datetime.
+ *
+ * Finally, for convenience (e.g. generating a random day then adding or subtracting days), we clamp
+ * the default range a bit further.
+ */
+export const DEFAULT_FROM = '1001-01-01';
+export const DEFAULT_TO = '9999-01-01';
+
+type DayString = string;
+
+/**
+ * Returns a randomly-selected ISO 8601 day string (`YYYY-MM-DD`), optionally between `from` and `to`.
+ * TODO(serhalp) Consider dropping support for `from` and `to` being `Date`s as this is complex to
+ * support and has many caveats.
  */
 const createDayGenerator = (chance: Chance.Chance) => (
-  from?: Date | string,
-  to?: Date | string,
+  from: Date | DayString = DEFAULT_FROM,
+  to: Date | DayString = DEFAULT_TO,
 ): string => {
+  if (typeof from === 'string' && !DAY_REGEX.test(from)) {
+    throw new TypeError('`from` must be a Date or a YYYY-MM-DD string');
+  }
+  if (typeof to === 'string' && !DAY_REGEX.test(to)) {
+    throw new TypeError('`to` must be a Date or a YYYY-MM-DD string');
+  }
+
   const _date = createDateGenerator(chance);
-  const date = _date(from, to);
+  // Note that much of what follows is dependent on the environment's time zone, which generally
+  // should always be avoided, but since we're generating random data here, it seems OK, especially
+  // given the alternative is to pull in a whole library like moment.js.
+  const date = _date(new Date(from), new Date(to));
   const year = String(date.getFullYear()).padStart(4, '0');
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const dayOfMonth = String(date.getDate()).padStart(2, '0');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,7 +23,6 @@ describe('the default export', function () {
     expect(fake.array(0, 2, fake.boolean)).toBeInstanceOf(Array);
     expect(fake.boolean()).toEqual(expect.any(Boolean));
     expect(fake.number()).toEqual(expect.any(Number));
-    expect(fake.day()).toEqual(expect.any(String));
     expect(fake.tzid()).toEqual(expect.any(String));
     const values = ['a', 'b', 'c'];
     expect(values).toContain(fake.sample(values));

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,14 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
 
+"@jest/console@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
+  dependencies:
+    "@jest/source-map" "^24.9.0"
+    chalk "^2.0.1"
+    slash "^2.0.0"
+
 "@jest/console@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
@@ -982,6 +990,14 @@
   optionalDependencies:
     node-notifier "^8.0.0"
 
+"@jest/source-map@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.9.0.tgz#0e263a94430be4b41da683ccc1e6bffe2a191714"
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.1.15"
+    source-map "^0.6.0"
+
 "@jest/source-map@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
@@ -989,6 +1005,14 @@
     callsites "^3.0.0"
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
+
+"@jest/test-result@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.9.0.tgz#11796e8aa9dbf88ea025757b3152595ad06ba0ca"
+  dependencies:
+    "@jest/console" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
 
 "@jest/test-result@^26.6.2":
   version "26.6.2"
@@ -1028,6 +1052,14 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
+
+"@jest/types@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^13.0.0"
 
 "@jest/types@^26.6.2":
   version "26.6.2"
@@ -1170,6 +1202,13 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
 "@types/istanbul-reports@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
@@ -1214,6 +1253,10 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1221,6 +1264,12 @@
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+
+"@types/yargs@^13.0.0":
+  version "13.0.11"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.11.tgz#def2f0c93e4bdf2c61d7e34899b17e34be28d3b1"
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.3"
@@ -1366,7 +1415,7 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
-ansi-regex@^4.1.0:
+ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
 
@@ -2088,6 +2137,10 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
 
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -2544,6 +2597,17 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect@^24.1.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
+  dependencies:
+    "@jest/types" "^24.9.0"
+    ansi-styles "^3.2.0"
+    jest-get-type "^24.9.0"
+    jest-matcher-utils "^24.9.0"
+    jest-message-util "^24.9.0"
+    jest-regex-util "^24.9.0"
+
 expect@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
@@ -2876,7 +2940,7 @@ graceful-fs@^4.1.11:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
 
@@ -3419,6 +3483,15 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
+jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
@@ -3466,6 +3539,22 @@ jest-environment-node@^26.6.2:
     "@types/node" "*"
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
+
+jest-extended@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-0.11.5.tgz#f063b3f1eaadad8d7c13a01f0dfe0f538d498ccf"
+  dependencies:
+    expect "^24.1.0"
+    jest-get-type "^22.4.3"
+    jest-matcher-utils "^22.0.0"
+
+jest-get-type@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+
+jest-get-type@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -3521,6 +3610,23 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-matcher-utils@^22.0.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
+
+jest-matcher-utils@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
@@ -3529,6 +3635,19 @@ jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-message-util@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^24.9.0"
+    "@jest/types" "^24.9.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^2.0.1"
+    micromatch "^3.1.10"
+    slash "^2.0.0"
+    stack-utils "^1.0.1"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -3554,6 +3673,10 @@ jest-mock@^26.6.2:
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
+
+jest-regex-util@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
 
 jest-regex-util@^26.0.0:
   version "26.0.0"
@@ -4625,6 +4748,22 @@ prettier@^2.1.2:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
 
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
+pretty-format@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
+  dependencies:
+    "@jest/types" "^24.9.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
+
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
@@ -4684,7 +4823,7 @@ ramda@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
 
-react-is@^16.8.1:
+react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
 
@@ -5225,6 +5364,12 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+stack-utils@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 stack-utils@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
See various inline comments. Basically, I made two changes:
- narrowed the default range from `[-271821-04-20, +275760-09-13]` to `[1001-01-1, 9999-01-01]`
  - it just isn't worthwhile nor pragmatic to continue to support this, IMO
- added runtime validation that provided `from` and `to` args are in the `YYYY-MM-DD` formats, since otherwise we cannot guarantee that the function will work as expected and generate days in the provided range (because allowing `new Date()` to parse arbitrary date formats results in undefined behavior)
  - this caused some extremely confusing issues for me a few weeks ago (as a consequence of the above range issue, but still seemed worth solving separately for good measure)