### PR TITLE
chore: configure number generation with precision

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,9 +170,9 @@ Useful for maybe types in Flow, e.g.:
 
 #### `fake.number`
 
-`(lowerInclusive?: number, upperExclusive?: number) => number`
+`(lowerInclusive?: number, upperExclusive?: number, fixed?: number) => number`
 
-Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive`.
+Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive` with a `fixed` number of digits after the decimal.
 
 #### `fake.objectId`
 

--- a/src/generators/number/index.test.ts
+++ b/src/generators/number/index.test.ts
@@ -1,0 +1,21 @@
+import {Chance} from 'chance';
+
+import createNumberGenerator from '.';
+
+describe('createNumberGenerator', function () {
+  it('rejects when `fixed` provided is greater than currently set MAX_PRECISION', function () {
+    const chance = new Chance();
+    const number = createNumberGenerator(chance);
+
+    expect(() => number(0, 10000, 7)).toThrowError(
+      '"fixed" must be less than or equal to 6 or null',
+    );
+  });
+
+  it('generates a random number', function () {
+    const chance = new Chance();
+    const number = createNumberGenerator(chance);
+
+    expect(number()).toEqual(expect.any(Number));
+  });
+});

--- a/src/generators/number/index.ts
+++ b/src/generators/number/index.ts
@@ -1,4 +1,4 @@
-import { Chance } from 'chance';
+import {Chance} from 'chance';
 
 /**
  * Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive` with `fixed` number of digits after the decimal.
@@ -20,6 +20,6 @@ const createNumberGenerator = (chance: Chance.Chance) => (
     max: upperExclusive - EPSILON,
     fixed,
   });
-}
+};
 
 export default createNumberGenerator;

--- a/src/generators/number/index.ts
+++ b/src/generators/number/index.ts
@@ -1,5 +1,7 @@
 import {Chance} from 'chance';
 
+const EPSILON = 0.0000001;
+const MAX_PRECISION = 6;
 /**
  * Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive` with `fixed` number of digits after the decimal.
  */
@@ -8,15 +10,13 @@ const createNumberGenerator = (chance: Chance.Chance) => (
   upperExclusive = 1000000,
   fixed = 4,
 ): number => {
-  const EPSILON = 0.0000001;
-  const MAX_PRECISION = 6;
-
-  if (upperExclusive != null && upperExclusive > MAX_PRECISION) {
-    throw new TypeError(`"upperExclusive" must be less than or equal to ${MAX_PRECISION} or null`);
+  if (fixed != null && fixed > MAX_PRECISION) {
+    throw new TypeError(`"fixed" must be less than or equal to ${MAX_PRECISION} or null`);
   }
 
   return chance.floating({
     min: lowerInclusive,
+    // chance.floating() returns 4 digits after the decimal by default, and its `max` is inclusive
     max: upperExclusive - EPSILON,
     fixed,
   });

--- a/src/generators/number/index.ts
+++ b/src/generators/number/index.ts
@@ -1,16 +1,17 @@
 import {Chance} from 'chance';
 
 /**
- * Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive`.
+ * Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive` with `fixed` number of digits after the decimal.
  */
 const createNumberGenerator = (chance: Chance.Chance) => (
   lowerInclusive = -1000000,
   upperExclusive = 1000000,
+  fixed = 4,
 ): number =>
   chance.floating({
     min: lowerInclusive,
-    // chance.floating() returns 4 digits after the decimal at most, and its `max` is inclusive
-    max: upperExclusive - 0.0001,
+    max: upperExclusive,
+    fixed,
   });
 
 export default createNumberGenerator;

--- a/src/generators/number/index.ts
+++ b/src/generators/number/index.ts
@@ -1,4 +1,4 @@
-import {Chance} from 'chance';
+import { Chance } from 'chance';
 
 /**
  * Generates a random `number`, optionally between `lowerInclusive` and `upperExclusive` with `fixed` number of digits after the decimal.
@@ -7,11 +7,19 @@ const createNumberGenerator = (chance: Chance.Chance) => (
   lowerInclusive = -1000000,
   upperExclusive = 1000000,
   fixed = 4,
-): number =>
-  chance.floating({
+): number => {
+  const EPSILON = 0.0000001;
+  const MAX_PRECISION = 6;
+
+  if (upperExclusive != null && upperExclusive > MAX_PRECISION) {
+    throw new TypeError(`"upperExclusive" must be less than or equal to ${MAX_PRECISION} or null`);
+  }
+
+  return chance.floating({
     min: lowerInclusive,
-    max: upperExclusive,
+    max: upperExclusive - EPSILON,
     fixed,
   });
+}
 
 export default createNumberGenerator;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,7 +22,6 @@ describe('the default export', function () {
     expect([null, true, false]).toContain(fake.nullable(fake.boolean));
     expect(fake.array(0, 2, fake.boolean)).toBeInstanceOf(Array);
     expect(fake.boolean()).toEqual(expect.any(Boolean));
-    expect(fake.number()).toEqual(expect.any(Number));
     expect(fake.tzid()).toEqual(expect.any(String));
     const values = ['a', 'b', 'c'];
     expect(values).toContain(fake.sample(values));


### PR DESCRIPTION
## Background
In order for Garbanzo to migrate away from `faker` and use fake-eggs instead, we need to support the case where a number needs to be generated up to N digits after the decimal point. See example: https://github.com/goodeggs/garbanzo/blob/master/src/domain/accounting/models/factories.js#L18

## Changes
- chore: added `fixed` (default as 4) as an additional input param when generating `.number()`

