### PR TITLE
Proxy chance.js methods when custom fake-eggs methods don't exist

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,4 +30,12 @@ describe('the default export', function () {
     expect(fake.uri()).toEqual(expect.any(String));
     expect(fake.zip()).toEqual(expect.any(String));
   });
+
+  it('proxies chance.js methods for unimplemented generators', () => {
+    // A random smattering of chance.js methods with and without arguments
+    expect(fake.coordinates()).toEqual(expect.any(String));
+    expect(fake.age()).toEqual(expect.any(Number));
+    expect(fake.ssn({ssnFour: true})).toMatch(/\d{4}/);
+    expect(fake.phone({country: 'us'})).toMatch(/\(\d{3}\)\s\d{3}-\d{4}/);
+  });
 });


### PR DESCRIPTION
## Background

We have established use of fake-eggs as the Good Eggs best practice for fake data generation. However, fake-eggs has many known gaps in the types of data it can generate (such as geolocation coordinates, currency, etc.). Meanwhile [chance.js](https://chancejs.com/index.html) the library that powers fake-eggs under the hood, has dozens of additional fake data generators not currently used by fake-eggs.

Currently the process when you have a need for a generator that is not currently provided by fake-eggs is to open a PR to that manually adds a generator for that specific type of data, merge the PR, and release a new version of fake-eggs. Also, frequently the added generator is a [thin wrapper that just forwards arguments to chance.js](https://github.com/goodeggs/fake-eggs/blob/8ea954d73d07010f2714bdcebb1cc4c5f656df03/src/generators/string/index.ts).

## Changes

This PR proposes using a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to fall back to calling chance.js's methods whenever a custom fake-eggs method does not exist, e.g., `fake.ssn()` will call `chance.ssn()` since fake-eggs does not have a custom `ssn` method defined, but `fake.integer()` would still use the custom-defined `integer` method. The proxy uses the seeded instance of `chance` so seeding is preserved.

Some benefits of this are:

* Vast increase in the types of fake date fake-eggs is capable of generating, making it much more likely that fake-eggs can be used in most contexts without the need for additional fake data libraries.
* We only need to create custom generators when we have a specific need to -- if we need the function signature to be different, we have specific desires for the returned data, or chance.js doesn't implement it. Otherwise, we can simply use chance.js's method for free.