### PR TITLE
fix: ensure (US) phoneNumbers have +1 prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/src/generators/phone_number/index.ts
+++ b/src/generators/phone_number/index.ts
@@ -4,6 +4,6 @@ import {Chance} from 'chance';
  * Generates a random phone number, e.g. `+15556797779`.
  */
 const createPhoneNumberGenerator = (chance: Chance.Chance) => (): string =>
-  `+${chance.phone({country: 'us', formatted: false})}`;
+  `+1${chance.phone({country: 'us', formatted: false})}`;
 
 export default createPhoneNumberGenerator;


### PR DESCRIPTION
## Background
Garbanzo's User model expects a phone number with a `+1` prefix, otherwise, [document validation fails](https://github.com/goodeggs/garbanzo/blob/master/src/orzo/server/models/user.js#L226). 

## Changes
- Prefix `+1` instead of `+` when generating a phone number

## ToDo
- [x] Publish a patch version once PR is approved