### PR TITLE
Add 2 letter state generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,14 @@ Chooses one of the elements of the provided `array`. The given array cannot be e
 
 `() => string`
 
+Generates a random sentence beginning with a capitalized letter and ending with a period.
+
+#### `fake.state`
+
+`() => string`
+
+Generates a random two letter state code, e.g., `CA`.
+
 #### `fake.string`
 
 `(length?: number, charset?: string) => string`

--- a/src/generators/state/index.test.ts
+++ b/src/generators/state/index.test.ts
@@ -1,0 +1,15 @@
+import {Chance} from 'chance';
+
+import createStateGenerator from '.';
+
+describe('state', () => {
+  it('generates a random state string', (): void => {
+    const chance = new Chance();
+    const state = createStateGenerator(chance);
+
+    const stateValue = state();
+
+    expect(stateValue).not.toBe(null);
+    expect(stateValue).toMatch(/^[A-Z][A-Z]$/);
+  });
+});

--- a/src/generators/state/index.ts
+++ b/src/generators/state/index.ts
@@ -1,0 +1,10 @@
+import {Chance} from 'chance';
+
+/**
+ * Returns a random 2 letter state (e.g., 'CA').
+ */
+const createStateGenerator = (chance: Chance.Chance) => (): string => {
+  return chance.state();
+};
+
+export default createStateGenerator;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,6 +26,7 @@ describe('the default export', function () {
     const values = ['a', 'b', 'c'];
     expect(values).toContain(fake.sample(values));
     expect(fake.digit()).toEqual(expect.any(Number));
+    expect(fake.state()).toEqual(expect.any(String));
     expect(fake.string()).toEqual(expect.any(String));
     expect(fake.uri()).toEqual(expect.any(String));
     expect(fake.zip()).toEqual(expect.any(String));

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import createProducerGenerators from './generators/producer';
 import createProductGenerators from './generators/product';
 import createSampleGenerator from './generators/sample';
 import createSentenceGenerator from './generators/sentence';
+import createStateGenerator from './generators/state';
 import createStringGenerator from './generators/string';
 import createTzidGenerator from './generators/tzid';
 import createUriGenerator from './generators/uri';
@@ -101,6 +102,7 @@ export const createFakeEggs = ({
     product: createProductGenerators(chance),
     sample: createSampleGenerator(chance),
     sentence: createSentenceGenerator(chance),
+    state: createStateGenerator(chance),
     string: createStringGenerator(chance),
     tzid: createTzidGenerator(chance),
     unique: createUniqueGenerator(chance),


### PR DESCRIPTION
Currently the way we fake state codes in Garbanzo is to generate a random two letter string, without checking if it is a state or not (see [here](https://github.com/goodeggs/garbanzo/blob/master/src/orzo/spec_helpers/factories.js#L69)). It would be more convenient if fake-eggs handled this.