### PR TITLE
Add `fake.location` and bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-eggs",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "description": "Generate Good Eggs-flavored data for development / test fixtures",
   "main": "dist/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,13 @@ fake.employee.email(); // => 'rylee.mayert@goodeggs.com
 automatically. Please update this manually when making changes, until we can add some entation
 auto-generation back in. -->
 
+#### `fake.address`
+
+`() => string`
+
+Generates a random street address string (e.g., `5447 Bazpe Lane`).
+Recommended to use its `fake.location.address` counterpart.
+
 #### `fake.array`
 
 `<T>(lengthLowerInclusive: number, lengthUpperExclusive: number, generator: () => T) => T[]`
@@ -158,6 +165,24 @@ Generates a random integer (could be negative!). Optionally between `lowerExclus
 
 Generates a random last name, e.g., `Armstrong`.
 
+#### `fake.location.address`
+
+`() => string`
+
+Generates a random street address string (e.g., `5447 Bazpe Lane`).
+
+#### `fake.location.state`
+
+`() => string`
+
+Generates a random two letter state code, e.g., `CA`.
+
+#### `fake.location.zip`
+
+Generate a random zip code (e.g. 55416) with the option of specifying a ZIP+4 format (e.g. 12201-7050)
+
+`(options?: {plusfour?: boolean}) => string`
+
 #### `fake.maybe`
 
 `<T>(returnValue: () => T) => ?T`
@@ -247,12 +272,6 @@ Chooses one of the elements of the provided `array`. The given array cannot be e
 
 Generates a random sentence beginning with a capitalized letter and ending with a period.
 
-#### `fake.state`
-
-`() => string`
-
-Generates a random two letter state code, e.g., `CA`.
-
 #### `fake.string`
 
 `(length?: number, charset?: string) => string`
@@ -316,7 +335,8 @@ Generate a random URI, e.g., `https://adl2j.goodeggs.com/ax/faj23`
 
 #### `fake.zip`
 
-Generate a random zip code (e.g. 55416) with the option of specifying a ZIP+4 format (e.g. 12201-7050)
+Generate a random zip code (e.g. 55416) with the option of specifying a ZIP+4 format (e.g. 12201-7050).
+Recommended to use its `fake.location.zip` counterpart.
 
 `(options?: {plusfour?: boolean}) => string`
 

--- a/src/generators/location/index.ts
+++ b/src/generators/location/index.ts
@@ -1,0 +1,13 @@
+import {Chance} from 'chance';
+
+import createAddressGenerator from '../address';
+import createStateGenerator from '../state';
+import createZipGenerator from '../zip';
+
+const createLocationGenerators = (chance: Chance.Chance) => ({
+  address: createAddressGenerator(chance),
+  state: createStateGenerator(chance),
+  zip: createZipGenerator(chance),
+});
+
+export default createLocationGenerators;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,7 +26,6 @@ describe('the default export', function () {
     const values = ['a', 'b', 'c'];
     expect(values).toContain(fake.sample(values));
     expect(fake.digit()).toEqual(expect.any(Number));
-    expect(fake.state()).toEqual(expect.any(String));
     expect(fake.string()).toEqual(expect.any(String));
     expect(fake.uri()).toEqual(expect.any(String));
     expect(fake.zip()).toEqual(expect.any(String));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import createFullNameGenerator from './generators/full_name';
 import createUniqueGenerator from './generators/unique';
 import createIntegerGenerator from './generators/integer';
 import createLastNameGenerator from './generators/last_name';
+import createLocationGenerators from './generators/location';
 import createMaybeCombinator from './combinators/maybe';
 import createNullableCombinator from './combinators/nullable';
 import createNumberGenerator from './generators/number';
@@ -26,7 +27,6 @@ import createProducerGenerators from './generators/producer';
 import createProductGenerators from './generators/product';
 import createSampleGenerator from './generators/sample';
 import createSentenceGenerator from './generators/sentence';
-import createStateGenerator from './generators/state';
 import createStringGenerator from './generators/string';
 import createTzidGenerator from './generators/tzid';
 import createUriGenerator from './generators/uri';
@@ -95,6 +95,7 @@ export const createFakeEggs = ({
     fullName: createFullNameGenerator(chance),
     integer: createIntegerGenerator(chance),
     lastName: createLastNameGenerator(chance),
+    location: createLocationGenerators(chance),
     number: createNumberGenerator(chance),
     objectId: createObjectIdGenerator(chance),
     phoneNumber: createPhoneNumberGenerators(chance),
@@ -102,7 +103,6 @@ export const createFakeEggs = ({
     product: createProductGenerators(chance),
     sample: createSampleGenerator(chance),
     sentence: createSentenceGenerator(chance),
-    state: createStateGenerator(chance),
     string: createStringGenerator(chance),
     tzid: createTzidGenerator(chance),
     unique: createUniqueGenerator(chance),


### PR DESCRIPTION
v6.4.0 contains:
- https://github.com/goodeggs/fake-eggs/pull/233, that lives under `fake.location.state`
- https://github.com/goodeggs/fake-eggs/pull/231
- Duplicating `fake.address` -> `fake.location.address` and `fake.zip` -> `fake.location.zip` to pad out `fake.location`. We can remove the former in a breaking version update if we'd like.