### PR TITLE
docs: fix misleading comment about env variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ export interface CreateFakeEggsOptions {
   /**
    * seed is an optional value that can be passed to the fake data generator to generate
    * repeatably random data (it will generate the same data for the same sequence of calls).
-   * When `process.env.FAKE_EGGS_SEED` is set to a non-empty value and `seed` is not explicitly
-   * passed, `process.env.FAKE_EGGS_SEED` will be used.
+   * When `process.env.FAKE_DATA_SEED` is set to a non-empty value and `seed` is not explicitly
+   * passed, `process.env.FAKE_DATA_SEED` will be used.
    *
    * This can be used, for example, to make it easier to reproduce flaky tests locally:
    *


### PR DESCRIPTION
The comment in `CreateFakeEggsOptions` erroneously described the environment variable to force use of a specific seed for random data as `process.env.FAKE_EGGS_SEED`. The actual name of the variable is `FAKE_DATA_SEED`. This PR just updates the comment to make it clear what environment variable to use to set the seed. I don't think a new release of fake-eggs is even required.